### PR TITLE
Add an example kubernetes deployment, fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,54 @@ imgpush requires docker
 docker run -v <PATH TO STORE IMAGES>:/images -p 5000:5000 hauxir/imgpush:latest
 ```
 
+### Kubernetes
+
+> This is fully optional and is only needed if you want to run imgpush in Kubernetes.
+
+If you want to deploy imgpush in Kubernetes, there is an example deployment available in the Kubernetes directory.
+In case you do not have a running Kubernetes cluster yet, you can use [Minikube](https://kubernetes.io/docs/setup/) to setup a local single-node Kubernetes cluster.
+Otherwise you can just use your existing cluster.
+
+1. Verify that your cluster works:
+```
+$ kubectl get pods
+# Should return without an error, maybe prints information about some deployed pods.
+```
+
+2. Apply the `kubernetes/deployment-example.yaml` file:
+```
+$ kubectl apply -f kubernetes/deployment-example.yaml
+namespace/imgpush created
+deployment.apps/imgpush created
+persistentvolumeclaim/imgpush created
+service/imgpush created
+```
+
+3. It will take a moment while your Kubernetes downloads the current imgpush image.
+4. Verify that the deployment was successful:
+```
+$ kubectl -n imgpush get deployments.
+NAME      READY   UP-TO-DATE   AVAILABLE   AGE
+imgpush   1/1     1            1           3m41s
+
+$ kubectl -n imgpush get svc
+NAME      TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
+imgpush   ClusterIP   10.10.10.41   <none>        5000/TCP   3m57s
+```
+
+5. When the deployment is finished, the READY column should be `1/1`.
+6. Afterwards you can forward the port to your local machine and upload an image via your webbrowser (visit http://127.0.0.1:5000/).
+```
+$ kubectl -n imgpush port-forward service/imgpush 5000
+Forwarding from 127.0.0.1:5000 -> 5000
+Handling connection for 5000
+Handling connection for 5000
+Handling connection for 5000
+Handling connection for 5000
+```
+
+7. To expose imgpush to the internet you need to configure an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). The exact configuration depends on you cluster but you can find an example in the `kubernetes/deployment-example.yaml` file that you can adapt to your setup.
+
 ## Configuration
 | Setting  | Default value | Description |
 | ------------- | ------------- |------------- |

--- a/kubernetes/deployment-example.yaml
+++ b/kubernetes/deployment-example.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: imgpush
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imgpush
+  namespace: imgpush
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: imgpush
+  template:
+    metadata:
+      labels:
+        app: imgpush
+    spec:
+      containers:
+      - image: hauxir/imgpush:latest
+        name: imgpush
+        ports:
+        - containerPort: 5000
+        env:
+        # Add your configuration as environment variables.
+        # See https://github.com/hauxir/imgpush#configuration for all
+        # available settings.
+        - name: OUTPUT_TYPE
+          value: png
+        imagePullPolicy: Always # Pull always because currently no version tags exist for the docker image.
+        volumeMounts:
+        - mountPath: /images
+          name: imgpush
+      volumes:
+      - name: imgpush
+        persistentVolumeClaim:
+          claimName: imgpush
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: imgpush
+  namespace: imgpush
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi # Adjust the size according to the amount of images you expect.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: imgpush
+  namespace: imgpush
+spec:
+  selector:
+    app: imgpush
+  ports:
+  - protocol: TCP
+    port: 5000
+    targetPort: 5000
+
+# To make imgpush available outside of your kubernetes cluster you need to
+# configure an ingress. The exact settings depend on your cluster.
+# This is an example ingress. It assumes that you have a nginx ingress
+# controller and cert-manager running. Adjust the settings for your cluster
+# and domain if you want to use it.
+
+#---
+#apiVersion: networking.k8s.io/v1beta1
+#kind: Ingress
+#metadata:
+#  name: imgpush
+#  namespace: imgpush
+#  annotations:
+#    kubernetes.io/ingress.class: "nginx"
+#    certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
+#    certmanager.k8s.io/acme-challenge-type: http01
+#spec:
+#  tls:
+#  - hosts:
+#    - imgpush.example.com
+#    secretName: imgpush-ssl
+#  rules:
+#  - host: imgpush.example.com
+#    http:
+#      paths:
+#      - path: /
+#        backend:
+#          serviceName: imgpush
+#          servicePort: 5000


### PR DESCRIPTION
Hi,
I wrote a small example kubernetes deployment that shows how imgpush could be used in kubernetes.
Best regards

```
$ kubectl apply -f kubernetes/deployment-example.yaml
namespace/imgpush created
deployment.apps/imgpush created
persistentvolumeclaim/imgpush created
service/imgpush created
```

```
$ kubectl -n imgpush get deployments.
NAME      READY   UP-TO-DATE   AVAILABLE   AGE
imgpush   1/1     1            1           3m41s
```

```
$ kubectl -n imgpush get svc
NAME      TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
imgpush   ClusterIP   10.10.10.41   <none>        5000/TCP   3m57s
```

Tested it by forwarding the port and uploading an image via my webbrowser:
```
$ kubectl -n imgpush port-forward service/imgpush 5000
Forwarding from 127.0.0.1:5000 -> 5000
Handling connection for 5000
Handling connection for 5000
Handling connection for 5000
Handling connection for 5000
```