### PR TITLE
Use nginx to proxy requests and serve static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.6-slim
 
 RUN apt-get update && \
     apt-get install -y \
-    libmagickwand-dev curl
+    libmagickwand-dev curl \
+    nginx
 
 COPY requirements.txt .
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 RUN pip install -r requirements.txt
 
@@ -17,4 +19,4 @@ COPY app /app
 
 WORKDIR /app
 
-CMD gunicorn --bind 0.0.0.0:5000 wsgi:app --access-logfile -
+CMD bash entrypoint.sh

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+nginx
+gunicorn --bind unix:imgpush.sock wsgi:app --access-logfile -

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 5000;
-    client_max_body_size 100M;
+    client_max_body_size 0;
     error_log /var/log/nginx/error.log debug;
 
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 5000;
+    client_max_body_size 100M;
+    error_log /var/log/nginx/error.log debug;
+
+    location / {
+        include proxy_params;
+        proxy_pass http://unix:/app/imgpush.sock;
+    }
+
+    location /nginx/ {
+        internal;
+        alias /;
+    }
+}


### PR DESCRIPTION
I'm using imgpush in production and traffic has grown quite a lot in the last days.
Following the advice here to serve the static files through nginx for better performance:
https://kite.com/python/docs/flask.send_from_directory