### PR TITLE
Adding a /metrics endpoint to expose the directory size and file count in prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Handling connection for 5000
 
 ### Liveness
 
-imgpush provides the `/liveness` endpoint that always returns `200 OK` that you can use for docker Healthcheck and kubernetes liveness probe. 
+imgpush provides the `/liveness` endpoint that always returns `200 OK` that you can use for Docker healthcheck and Kubernetes liveness probe. 
 
-For Docker, as `curl` is install in the image : 
+For Docker, as `curl` is installed in the image : 
 
 ```yaml
 healthcheck:
@@ -103,6 +103,27 @@ livenessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30
 ```
+
+### Metrics
+
+imgpush provides the `/metrics` endpoint that returns metrics which can be imported in Prometheus, with the size of the `/images` directory (in kilobytes) and the number of files in it :
+
+```
+directory_size{directory="/images", service="imgpush"} 202724
+directory_count{directory="/images", service="imgpush"} 2464
+```
+
+In order to scrape it, just add a config under `scrape_configs:` in your Prometheus configuration with the url of the instance (here, to scrape 'https://imgpush.myap.com`)
+
+```yml
+scrape_configs:
+  - job_name: 'imgpush_app_insight'
+    scheme: https
+    static_configs:
+    - targets: ['imgpush.myapp.com']
+```
+
+then you can monitor your imgpush instance ( and compute an average image size, get the increase rate, ... ). 
 
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -6,6 +6,7 @@ import random
 import string
 import urllib.request
 import uuid
+import subprocess
 
 import filetype
 import timeout_decorator
@@ -254,6 +255,12 @@ def get_image(filename):
 
     return send_from_directory(settings.IMAGES_DIR, filename)
 
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    ps = subprocess.Popen("ls -1 /images | wc -l" ,shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    nbfiles = ps.communicate()[0].split()[0].decode('utf-8')
+    size = subprocess.check_output(['du','-s', "/images"]).split()[0].decode('utf-8')
+    return 'directory_size{service=\"imgpush\", directory=\"/images\"} %s\ndirectory_count{service=\"imgpsuh\", directory=\"/images\"} %s' % (size, nbfiles)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, threaded=True)


### PR DESCRIPTION
Add the `/metrics` endpoint that returns metrics which can be imported in Prometheus, with the size of the `/images` directory (in kilobytes) and the number of files in it :

```
directory_size{directory="/images", service="imgpush"} 202724
directory_count{directory="/images", service="imgpush"} 2464
```

In order to scrape it, just add a config under `scrape_configs:` in your Prometheus configuration with the url of the instance (here, to scrape 'https://imgpush.myap.com`)

```yml
scrape_configs:
  - job_name: 'imgpush_app_insight'
    scheme: https
    static_configs:
    - targets: ['imgpush.myapp.com']
```

then you can monitor your imgpush instance ( and compute an average image size, get the increase rate, ... ). 

For instance, with Grafana
![image](https://user-images.githubusercontent.com/1388970/182933949-c8648e62-9df8-42f1-820f-3511442fa1fe.png)
