### PR TITLE
Add delete endpoint with API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Minimalist Self-hosted Image Service for user submitted images in your app (e.g.
 - Automatic resizing to any size of your liking
 - Built-in Rate limiting
 - Built-in Allowed Origin whitelisting
-- Liveness API 
+- Liveness API
+- Delete API with API key authentication 
 
 ## Usage
 Uploading an image:
@@ -15,15 +16,27 @@ Uploading an image:
 > curl -F 'file=@/some/file.jpg' http://some.host
 {"filename":"somename.png"}
 ```
+Uploading an image with authentication (when `API_KEY` and `REQUIRE_API_KEY_FOR_UPLOAD` are set):
+```bash
+> curl -F 'file=@/some/file.jpg' -H "Authorization: Bearer your-api-key" http://some.host
+{"filename":"somename.png"}
+```
 Uploading an image by URL:
 ```bash
- curl -X POST -H "Content-Type: application/json" -d '{"url": "<SOME_URL>"}'  http://some.host
- ```
+> curl -X POST -H "Content-Type: application/json" -d '{"url": "<SOME_URL>"}'  http://some.host
+```
 Fetching a file in a specific size(e.g. 320x240):
 ```
 http://some.host/somename.png?w=320&h=240
 ```
 returns the image cropped to the desired size
+
+Deleting an image (requires `API_KEY` to be set):
+```bash
+> curl -X DELETE -H "Authorization: Bearer your-api-key" http://some.host/somename.png
+{"status":"deleted","cached_files_removed":"3"}
+```
+This removes the original image and all cached resized versions.
 
 ## Running
 imgpush requires docker
@@ -120,6 +133,10 @@ livenessProbe:
 | NUDE_FILTER_MAX_THRESHOLD  | None  | max unsafe value returned from nudenet library(https://github.com/notAI-tech/NudeNet), range is from 0-0.99. Blocks nudity from being uploaded. |
 | NUDE_FILTER_VIDEO_INTERVAL  | 1.0  | Float, seconds between frame samples when checking videos for nudity. Only applies when ALLOW_VIDEO and NUDE_FILTER_MAX_THRESHOLD are both set. |
 | MAX_VIDEO_DURATION  | 60.0  | Float, maximum video duration in seconds. Videos exceeding this limit are rejected. |
+| API_KEY  | None  | String, API key for authentication. Pass via `Authorization: Bearer <key>` header. |
+| REQUIRE_API_KEY_FOR_UPLOAD  | False  | Boolean, require API key for uploads. |
+| REQUIRE_API_KEY_FOR_DELETE  | True  | Boolean, require API key for deletes. Delete is disabled if API_KEY is not set. |
+| MAX_API_KEY_ATTEMPTS_PER_MINUTE  | 5  | Integer, max failed API key attempts per IP per minute. |
 
 Setting configuration variables is all set through env variables that get passed to the docker container.
 ### Example:

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,6 +17,10 @@ NUDE_FILTER_VIDEO_INTERVAL: float = 1.0
 ALLOW_VIDEO: bool = False
 MAX_VIDEO_DURATION: float = 60.0
 HIDE_UPLOAD_FORM: bool = False
+API_KEY: Optional[str] = None
+REQUIRE_API_KEY_FOR_UPLOAD: bool = False
+REQUIRE_API_KEY_FOR_DELETE: bool = True
+MAX_API_KEY_ATTEMPTS_PER_MINUTE: int = 5
 
 VALID_SIZES: list[int] = []
 

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -120,3 +120,219 @@ class TestGetImageEndpoint:
     def test_get_nonexistent_image_returns_404(self, client, temp_dirs):
         response = client.get("/nonexistent.png")
         assert response.status_code == 404
+
+
+@pytest.fixture
+def reset_rate_limiter():
+    """Reset the rate limiter storage between tests."""
+    from app import _auth_limiter
+    _auth_limiter.storage.reset()
+    yield
+    _auth_limiter.storage.reset()
+
+
+@pytest.fixture
+def enable_api_key(monkeypatch):
+    """Enable API key authentication."""
+    monkeypatch.setattr("settings.API_KEY", "test-key")
+    monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_DELETE", True)
+    return "test-key"
+
+
+class TestDeleteEndpoint:
+    def test_delete_disabled_without_api_key(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.API_KEY", None)
+
+        response = client.delete("/test.png", headers={"Authorization": "Bearer any"})
+        assert response.status_code == 403
+        assert "disabled" in response.json()["detail"]
+
+    def test_delete_disabled_when_not_required(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.API_KEY", "test-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_DELETE", False)
+
+        response = client.delete("/test.png", headers={"Authorization": "Bearer test-key"})
+        assert response.status_code == 403
+        assert "disabled" in response.json()["detail"]
+
+    def test_delete_invalid_api_key(self, client, temp_dirs, enable_api_key):
+        response = client.delete("/test.png", headers={"Authorization": "Bearer wrong-key"})
+        assert response.status_code == 403
+        assert "Invalid API key" in response.json()["detail"]
+
+    def test_delete_missing_auth_header(self, client, temp_dirs, enable_api_key):
+        response = client.delete("/test.png")
+        assert response.status_code == 403
+        assert "Authorization required" in response.json()["detail"]
+
+    def test_delete_invalid_auth_header_format(self, client, temp_dirs, enable_api_key):
+        response = client.delete("/test.png", headers={"Authorization": "Basic abc123"})
+        assert response.status_code == 403
+        assert "Authorization required" in response.json()["detail"]
+
+    def test_delete_nonexistent_file(self, client, temp_dirs, enable_api_key):
+        response = client.delete("/nonexistent.png", headers={"Authorization": "Bearer test-key"})
+        assert response.status_code == 404
+
+    def test_delete_path_traversal_blocked(self, client, temp_dirs, enable_api_key):
+        # URL-encoded path traversal attempt (..%2F = ../)
+        response = client.delete("/..%2F..%2F..%2Fetc/passwd", headers={"Authorization": "Bearer test-key"})
+        assert response.status_code == 400
+        assert "Invalid filename" in response.json()["detail"]
+
+    def test_delete_existing_file(self, client, temp_dirs, enable_api_key):
+        # Create a test file
+        test_filename = "test123.png"
+        test_path = os.path.join(temp_dirs["images"], test_filename)
+        with open(test_path, "wb") as f:
+            f.write(b"test content")
+
+        assert os.path.exists(test_path)
+
+        response = client.delete(f"/{test_filename}", headers={"Authorization": "Bearer test-key"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "deleted"
+
+        # Verify file was deleted
+        assert not os.path.exists(test_path)
+
+    def test_delete_removes_cached_files(self, client, temp_dirs, enable_api_key):
+        # Create original file and cached versions
+        test_filename = "test123.png"
+        test_path = os.path.join(temp_dirs["images"], test_filename)
+        with open(test_path, "wb") as f:
+            f.write(b"original")
+
+        # Create cached resized versions
+        cached_files = [
+            "test123_100x100.png",
+            "test123_200x150.png",
+            "test123_50x50.png",
+        ]
+        for cached_name in cached_files:
+            cached_path = os.path.join(temp_dirs["cache"], cached_name)
+            with open(cached_path, "wb") as f:
+                f.write(b"cached")
+
+        response = client.delete(f"/{test_filename}", headers={"Authorization": "Bearer test-key"})
+        assert response.status_code == 200
+        assert response.json()["cached_files_removed"] == "3"
+
+        # Verify all files were deleted
+        assert not os.path.exists(test_path)
+        for cached_name in cached_files:
+            assert not os.path.exists(os.path.join(temp_dirs["cache"], cached_name))
+
+    def test_delete_rate_limits_failed_attempts(self, client, temp_dirs, monkeypatch, reset_rate_limiter):
+        monkeypatch.setattr("settings.API_KEY", "correct-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_DELETE", True)
+
+        # Update the parsed rate limit to use new value
+        from limits import parse as parse_limit
+
+        import app as app_module
+        app_module._failed_auth_limit = parse_limit("3/minute")
+
+        # Make 3 failed attempts (should all return 403)
+        for i in range(3):
+            response = client.delete("/test.png", headers={"Authorization": "Bearer wrong-key"})
+            assert response.status_code == 403, f"Attempt {i+1} should return 403"
+
+        # 4th attempt should be rate limited
+        response = client.delete("/test.png", headers={"Authorization": "Bearer wrong-key"})
+        assert response.status_code == 429
+        assert "Too many failed attempts" in response.json()["detail"]
+
+    def test_delete_rate_limit_does_not_affect_valid_requests(self, client, temp_dirs, monkeypatch, reset_rate_limiter):
+        monkeypatch.setattr("settings.API_KEY", "correct-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_DELETE", True)
+
+        # Update the parsed rate limit
+        from limits import parse as parse_limit
+
+        import app as app_module
+        app_module._failed_auth_limit = parse_limit("2/minute")
+
+        # Make 2 failed attempts
+        for _ in range(2):
+            response = client.delete("/test.png", headers={"Authorization": "Bearer wrong-key"})
+            assert response.status_code == 403
+
+        # Valid request should still work (creates file first)
+        test_filename = "valid-delete.png"
+        test_path = os.path.join(temp_dirs["images"], test_filename)
+        with open(test_path, "wb") as f:
+            f.write(b"content")
+
+        response = client.delete(f"/{test_filename}", headers={"Authorization": "Bearer correct-key"})
+        assert response.status_code == 200
+
+
+class TestUploadAuth:
+    def test_upload_works_without_auth_when_not_required(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.NUDE_FILTER_MAX_THRESHOLD", None)
+        monkeypatch.setattr("settings.API_KEY", "test-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_UPLOAD", False)
+
+        png_data = bytes([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+            0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+            0x42, 0x60, 0x82
+        ])
+
+        response = client.post("/", files={"file": ("test.png", png_data, "image/png")})
+        assert response.status_code == 200
+
+    def test_upload_requires_auth_when_enabled(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.API_KEY", "test-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_UPLOAD", True)
+
+        png_data = bytes([0x89, 0x50, 0x4E, 0x47])  # minimal PNG header
+
+        response = client.post("/", files={"file": ("test.png", png_data, "image/png")})
+        assert response.status_code == 403
+        assert "Authorization required" in response.json()["detail"]
+
+    def test_upload_with_valid_auth(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.NUDE_FILTER_MAX_THRESHOLD", None)
+        monkeypatch.setattr("settings.API_KEY", "test-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_UPLOAD", True)
+
+        png_data = bytes([
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+            0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+            0x42, 0x60, 0x82
+        ])
+
+        response = client.post(
+            "/",
+            files={"file": ("test.png", png_data, "image/png")},
+            headers={"Authorization": "Bearer test-key"}
+        )
+        assert response.status_code == 200
+
+    def test_upload_with_invalid_auth(self, client, temp_dirs, monkeypatch):
+        monkeypatch.setattr("settings.API_KEY", "test-key")
+        monkeypatch.setattr("settings.REQUIRE_API_KEY_FOR_UPLOAD", True)
+
+        png_data = bytes([0x89, 0x50, 0x4E, 0x47])
+
+        response = client.post(
+            "/",
+            files={"file": ("test.png", png_data, "image/png")},
+            headers={"Authorization": "Bearer wrong-key"}
+        )
+        assert response.status_code == 403
+        assert "Invalid API key" in response.json()["detail"]


### PR DESCRIPTION
### **User description**
- DELETE /{filename} removes image and all cached resized versions
- Requires X-API-Key header matching DELETE_API_KEY env var
- Rate limits failed API key attempts using slowapi
- Returns 403 if disabled or invalid key, 404 if file not found
- Adds DELETE_API_KEY and MAX_DELETE_KEY_ATTEMPTS_PER_MINUTE settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds DELETE endpoint with API key authentication

- Removes original image and all cached resized versions

- Rate limits failed API key attempts per IP address

- Includes comprehensive test coverage for delete functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client Request"]
  ValidateKey["Validate X-API-Key Header"]
  CheckEnabled["Check DELETE_API_KEY Setting"]
  RateLimit["Rate Limit Failed Attempts"]
  DeleteImg["Delete Image & Cache"]
  Response["Return Status"]
  
  Client -- "DELETE /{filename}" --> ValidateKey
  ValidateKey -- "Key Missing" --> Response
  ValidateKey -- "Key Present" --> CheckEnabled
  CheckEnabled -- "Disabled" --> Response
  CheckEnabled -- "Enabled" --> RateLimit
  RateLimit -- "Too Many Failures" --> Response
  RateLimit -- "Valid Key" --> DeleteImg
  DeleteImg -- "Success/Error" --> Response
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Add DELETE endpoint with rate limiting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/app.py

<ul><li>Imports <code>Header</code> from fastapi and <code>parse_limit</code> from limits library<br> <li> Initializes rate limiter for failed delete API key attempts<br> <li> Implements DELETE endpoint handler with API key validation<br> <li> Validates DELETE_API_KEY setting and enforces rate limiting on failed <br>attempts</ul>


</details>


  </td>
  <td><a href="https://github.com/hauxir/imgpush/pull/42/files#diff-fc3b1a787c6d94d379c141d039d3d5eb98ba8804720945de123abb50a167006c">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>imgpush.py</strong><dd><code>Add image deletion with cache cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/imgpush.py

<ul><li>Adds <code>delete_image()</code> function to remove image and cached versions<br> <li> Deletes original file from IMAGES_DIR<br> <li> Uses glob pattern matching to find and delete all cached resized <br>versions<br> <li> Returns count of deleted cached files</ul>


</details>


  </td>
  <td><a href="https://github.com/hauxir/imgpush/pull/42/files#diff-22516f9597f331a3d566312bccd3c0c1cefb4074741cc8652f219a53d4e09e1d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Add delete endpoint configuration settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/settings.py

<ul><li>Adds <code>DELETE_API_KEY</code> optional string setting (defaults to None)<br> <li> Adds <code>MAX_DELETE_KEY_ATTEMPTS_PER_MINUTE</code> integer setting (defaults to <br>5)<br> <li> Allows disabling delete endpoint when DELETE_API_KEY is not set</ul>


</details>


  </td>
  <td><a href="https://github.com/hauxir/imgpush/pull/42/files#diff-1583acfd980120d1beffb569a94b26ccd42c7311b8d5b0193d009fb5207edb05">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_app.py</strong><dd><code>Add comprehensive delete endpoint tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/tests/test_app.py

<ul><li>Adds <code>reset_rate_limiter</code> fixture to reset rate limiter between tests<br> <li> Implements comprehensive TestDeleteEndpoint class with 8 test methods<br> <li> Tests endpoint disabled state, API key validation, missing headers<br> <li> Tests file deletion, cached file removal, and rate limiting behavior<br> <li> Verifies rate limiting doesn't affect valid authenticated requests</ul>


</details>


  </td>
  <td><a href="https://github.com/hauxir/imgpush/pull/42/files#diff-33dc0b997f0cfdf0096c60eea32614ee822ad214b7f70d009b952d989255b205">+126/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document delete endpoint and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds delete API feature to feature list<br> <li> Documents DELETE endpoint usage with curl example<br> <li> Explains that endpoint removes original and cached files<br> <li> Documents DELETE_API_KEY and MAX_DELETE_KEY_ATTEMPTS_PER_MINUTE <br>settings</ul>


</details>


  </td>
  <td><a href="https://github.com/hauxir/imgpush/pull/42/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

