### PR TITLE
Add admin endpoint to stream list of stored filenames

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import secrets
 import urllib.request
@@ -207,12 +208,12 @@ def list_files(
                     continue
                 if prefix and not entry.name.startswith(prefix):
                     continue
-                yield entry.name + "\n"
+                yield json.dumps(entry.name) + "\n"
                 count += 1
                 if limit and count >= limit:
                     return
 
-    return StreamingResponse(iter_names(), media_type="text/plain")
+    return StreamingResponse(iter_names(), media_type="application/x-ndjson")
 
 
 @app.delete("/{filename:path}")

--- a/app/app.py
+++ b/app/app.py
@@ -10,7 +10,7 @@ import settings
 import video
 from fastapi import FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
 from limits import parse as parse_limit
 from limits.storage import MemoryStorage
 from limits.strategies import FixedWindowRateLimiter
@@ -188,6 +188,31 @@ async def upload_image(
         raise HTTPException(status_code=400, detail=error)
 
     return {"filename": output_filename}
+
+
+@app.get("/admin/files")
+def list_files(
+    request: Request,
+    prefix: str = Query(default=""),
+    limit: int = Query(default=0, ge=0),
+    authorization: Optional[str] = Header(default=None),
+) -> StreamingResponse:
+    check_auth(request, authorization)
+
+    def iter_names() -> Any:
+        count = 0
+        with os.scandir(settings.IMAGES_DIR) as it:
+            for entry in it:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if prefix and not entry.name.startswith(prefix):
+                    continue
+                yield entry.name + "\n"
+                count += 1
+                if limit and count >= limit:
+                    return
+
+    return StreamingResponse(iter_names(), media_type="text/plain")
 
 
 @app.delete("/{filename:path}")


### PR DESCRIPTION
## Summary
- Adds `GET /admin/files` that streams filenames from `IMAGES_DIR` one per line (`text/plain`), using `os.scandir` so memory usage is flat regardless of store size.
- Gated by the existing Bearer `API_KEY` via `check_auth`.
- Supports optional `?prefix=` filtering and `?limit=` for sampling.
- Registered before the `/{filename:path}` catch-all so it is not swallowed as a filename lookup.

Usage:
```
curl -H "Authorization: Bearer \$API_KEY" https://host/admin/files > all.txt
```

## Test plan
- [ ] `curl` with valid key returns filenames, one per line
- [ ] `curl` without / with wrong key returns 403
- [ ] `?prefix=abc` filters results
- [ ] `?limit=10` caps results
- [ ] Response begins streaming immediately on a large directory (no full-list buffering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)