### PR TITLE
Add optional sharded on-disk layout for images and cache

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -180,7 +180,7 @@ async def upload_image(
         output_type = "svg"
 
     output_filename = os.path.basename(tmp_filepath) + f".{output_type}"
-    output_path = os.path.join(settings.IMAGES_DIR, output_filename)
+    output_path = imgpush.resolve_path(settings.IMAGES_DIR, output_filename, create_parents=True)
 
     error = imgpush.process_image(tmp_filepath, output_path, output_type, is_svg)
 
@@ -217,14 +217,14 @@ def get_image(
     w: str = Query(default=""),
     h: str = Query(default=""),
 ) -> FileResponse:
-    path = os.path.join(settings.IMAGES_DIR, filename)
+    path = imgpush.resolve_existing_path(settings.IMAGES_DIR, filename)
 
-    if not os.path.isfile(path):
+    if path is None:
         raise HTTPException(status_code=404, detail="File not found")
 
     filename_without_extension, extension = os.path.splitext(filename)
 
-    if (w or h) and os.path.isfile(path) and extension not in (".mp4", ".svg"):
+    if (w or h) and extension not in (".mp4", ".svg"):
         try:
             width = imgpush.get_size_from_string(w)
             height = imgpush.get_size_from_string(h)
@@ -237,7 +237,7 @@ def get_image(
         dimensions = f"{width}x{height}"
         resized_filename = filename_without_extension + f"_{dimensions}{extension}"
 
-        resized_path = os.path.join(settings.CACHE_DIR, resized_filename)
+        resized_path = imgpush.resolve_path(settings.CACHE_DIR, resized_filename, create_parents=True)
 
         if not os.path.isfile(resized_path) and (width or height):
             imgpush.clear_imagemagick_temp_files()

--- a/app/imgpush.py
+++ b/app/imgpush.py
@@ -45,6 +45,40 @@ class PathTraversalError(Exception):
     pass
 
 
+SHARD_SEGMENT_LEN = 2
+SHARD_DEPTH = 2
+
+
+def _shard_segments(filename: str) -> list[str]:
+    key = filename[: SHARD_SEGMENT_LEN * SHARD_DEPTH]
+    return [key[i * SHARD_SEGMENT_LEN : (i + 1) * SHARD_SEGMENT_LEN] for i in range(SHARD_DEPTH)]
+
+
+def resolve_path(base_dir: str, filename: str, create_parents: bool = False) -> str:
+    """Map a filename to its on-disk path under base_dir, respecting SHARD_STORAGE."""
+    if not settings.SHARD_STORAGE:
+        return os.path.join(base_dir, filename)
+    path = os.path.join(base_dir, *_shard_segments(filename), filename)
+    if create_parents:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    return path
+
+
+def resolve_existing_path(base_dir: str, filename: str) -> Optional[str]:
+    """Return the actual path of filename under base_dir, whether flat or sharded.
+
+    Supports mixed-era installs where some files exist flat and others sharded.
+    """
+    flat = os.path.join(base_dir, filename)
+    if os.path.isfile(flat):
+        return flat
+    if settings.SHARD_STORAGE:
+        sharded = os.path.join(base_dir, *_shard_segments(filename), filename)
+        if os.path.isfile(sharded):
+            return sharded
+    return None
+
+
 def get_size_from_string(size: str) -> Union[int, str]:
     try:
         size_int = int(size)
@@ -76,7 +110,8 @@ def clear_imagemagick_temp_files() -> None:
 def get_random_filename() -> str:
     random_string = generate_random_filename()
     if settings.NAME_STRATEGY == "randomstr":
-        file_exists = len(glob.glob(f"{settings.IMAGES_DIR}/{random_string}.*")) > 0
+        search_dir = os.path.dirname(resolve_path(settings.IMAGES_DIR, random_string + ".x"))
+        file_exists = len(glob.glob(f"{search_dir}/{random_string}.*")) > 0
         if file_exists:
             return get_random_filename()
     return random_string
@@ -165,7 +200,8 @@ def delete_image(filename: str) -> int:
     Raises PathTraversalError if filename attempts directory traversal.
     """
     # Sanitize filename to prevent path traversal
-    image_path = os.path.realpath(os.path.join(settings.IMAGES_DIR, filename))
+    candidate = resolve_existing_path(settings.IMAGES_DIR, filename) or os.path.join(settings.IMAGES_DIR, filename)
+    image_path = os.path.realpath(candidate)
     images_dir = os.path.realpath(settings.IMAGES_DIR)
 
     if not image_path.startswith(images_dir + os.sep):
@@ -179,7 +215,8 @@ def delete_image(filename: str) -> int:
     # Also sanitize cache path - escape glob special chars in filename
     safe_filename = os.path.basename(image_path)
     filename_without_ext, extension = os.path.splitext(safe_filename)
-    cache_pattern = os.path.join(settings.CACHE_DIR, f"{glob.escape(filename_without_ext)}_*x*{glob.escape(extension)}")
+    cache_dir = os.path.dirname(resolve_path(settings.CACHE_DIR, safe_filename))
+    cache_pattern = os.path.join(cache_dir, f"{glob.escape(filename_without_ext)}_*x*{glob.escape(extension)}")
     cached_files = glob.glob(cache_pattern)
 
     for cached_file in cached_files:

--- a/app/imgpush.py
+++ b/app/imgpush.py
@@ -49,6 +49,11 @@ SHARD_SEGMENT_LEN = 2
 SHARD_DEPTH = 2
 
 
+def _is_safe_filename(filename: str) -> bool:
+    """Reject anything that isn't a plain basename (blocks path traversal)."""
+    return bool(filename) and filename not in (".", "..") and filename == os.path.basename(filename)
+
+
 def _shard_segments(filename: str) -> list[str]:
     key = filename[: SHARD_SEGMENT_LEN * SHARD_DEPTH]
     return [key[i * SHARD_SEGMENT_LEN : (i + 1) * SHARD_SEGMENT_LEN] for i in range(SHARD_DEPTH)]
@@ -56,6 +61,8 @@ def _shard_segments(filename: str) -> list[str]:
 
 def resolve_path(base_dir: str, filename: str, create_parents: bool = False) -> str:
     """Map a filename to its on-disk path under base_dir, respecting SHARD_STORAGE."""
+    if not _is_safe_filename(filename):
+        raise PathTraversalError("Invalid filename")
     if not settings.SHARD_STORAGE:
         return os.path.join(base_dir, filename)
     path = os.path.join(base_dir, *_shard_segments(filename), filename)
@@ -68,7 +75,10 @@ def resolve_existing_path(base_dir: str, filename: str) -> Optional[str]:
     """Return the actual path of filename under base_dir, whether flat or sharded.
 
     Supports mixed-era installs where some files exist flat and others sharded.
+    Returns None for invalid filenames (path traversal attempts) or misses.
     """
+    if not _is_safe_filename(filename):
+        return None
     flat = os.path.join(base_dir, filename)
     if os.path.isfile(flat):
         return flat
@@ -215,9 +225,12 @@ def delete_image(filename: str) -> int:
     # Also sanitize cache path - escape glob special chars in filename
     safe_filename = os.path.basename(image_path)
     filename_without_ext, extension = os.path.splitext(safe_filename)
-    cache_dir = os.path.dirname(resolve_path(settings.CACHE_DIR, safe_filename))
-    cache_pattern = os.path.join(cache_dir, f"{glob.escape(filename_without_ext)}_*x*{glob.escape(extension)}")
-    cached_files = glob.glob(cache_pattern)
+    variant_suffix = f"{glob.escape(filename_without_ext)}_*x*{glob.escape(extension)}"
+    sharded_cache_dir = os.path.dirname(resolve_path(settings.CACHE_DIR, safe_filename))
+    cache_patterns = [os.path.join(settings.CACHE_DIR, variant_suffix)]
+    if sharded_cache_dir != settings.CACHE_DIR.rstrip(os.sep):
+        cache_patterns.append(os.path.join(sharded_cache_dir, variant_suffix))
+    cached_files = [p for pattern in cache_patterns for p in glob.glob(pattern)]
 
     for cached_file in cached_files:
         os.remove(cached_file)

--- a/app/migrate_shard.py
+++ b/app/migrate_shard.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Migrate a flat image/cache directory into the sharded layout.
+
+Moves every file in the top level of BASE_DIR into its shard path
+(BASE_DIR/ab/cd/<file>). Idempotent and safe to re-run: files already
+inside a shard subdirectory are skipped. Intended to be run with the
+app stopped (or uploads paused) so no new files are written mid-move.
+
+Usage:
+    python migrate_shard.py /images
+    python migrate_shard.py /cache --dry-run
+"""
+import argparse
+import os
+import sys
+
+SHARD_SEGMENT_LEN = 2
+SHARD_DEPTH = 2
+
+
+def shard_segments(filename: str) -> list[str]:
+    key = filename[: SHARD_SEGMENT_LEN * SHARD_DEPTH]
+    return [key[i * SHARD_SEGMENT_LEN : (i + 1) * SHARD_SEGMENT_LEN] for i in range(SHARD_DEPTH)]
+
+
+def migrate(base_dir: str, dry_run: bool) -> tuple[int, int]:
+    moved = 0
+    skipped = 0
+    with os.scandir(base_dir) as it:
+        for entry in it:
+            if not entry.is_file(follow_symlinks=False):
+                skipped += 1
+                continue
+            segments = shard_segments(entry.name)
+            if any(not s for s in segments):
+                print(f"skip (name too short for shard): {entry.name}", file=sys.stderr)
+                skipped += 1
+                continue
+            target_dir = os.path.join(base_dir, *segments)
+            target = os.path.join(target_dir, entry.name)
+            if dry_run:
+                print(f"would move {entry.path} -> {target}")
+            else:
+                os.makedirs(target_dir, exist_ok=True)
+                os.rename(entry.path, target)
+            moved += 1
+    return moved, skipped
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("base_dir", help="Directory to migrate (e.g. /images or /cache)")
+    p.add_argument("--dry-run", action="store_true", help="Show planned moves without touching disk")
+    args = p.parse_args()
+
+    if not os.path.isdir(args.base_dir):
+        print(f"not a directory: {args.base_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    moved, skipped = migrate(args.base_dir, args.dry_run)
+    verb = "would move" if args.dry_run else "moved"
+    print(f"{verb} {moved} file(s), skipped {skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/migrate_shard.py
+++ b/app/migrate_shard.py
@@ -23,9 +23,10 @@ def shard_segments(filename: str) -> list[str]:
     return [key[i * SHARD_SEGMENT_LEN : (i + 1) * SHARD_SEGMENT_LEN] for i in range(SHARD_DEPTH)]
 
 
-def migrate(base_dir: str, dry_run: bool) -> tuple[int, int]:
+def migrate(base_dir: str, dry_run: bool) -> tuple[int, int, int]:
     moved = 0
     skipped = 0
+    failed = 0
     with os.scandir(base_dir) as it:
         for entry in it:
             if not entry.is_file(follow_symlinks=False):
@@ -38,13 +39,23 @@ def migrate(base_dir: str, dry_run: bool) -> tuple[int, int]:
                 continue
             target_dir = os.path.join(base_dir, *segments)
             target = os.path.join(target_dir, entry.name)
+            if os.path.exists(target):
+                print(f"skip (target exists): {entry.path}", file=sys.stderr)
+                skipped += 1
+                continue
             if dry_run:
                 print(f"would move {entry.path} -> {target}")
-            else:
+                moved += 1
+                continue
+            try:
                 os.makedirs(target_dir, exist_ok=True)
                 os.rename(entry.path, target)
+            except OSError as exc:
+                print(f"failed {entry.path} -> {target}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
             moved += 1
-    return moved, skipped
+    return moved, skipped, failed
 
 
 def main() -> None:
@@ -57,9 +68,11 @@ def main() -> None:
         print(f"not a directory: {args.base_dir}", file=sys.stderr)
         sys.exit(1)
 
-    moved, skipped = migrate(args.base_dir, args.dry_run)
+    moved, skipped, failed = migrate(args.base_dir, args.dry_run)
     verb = "would move" if args.dry_run else "moved"
-    print(f"{verb} {moved} file(s), skipped {skipped}")
+    print(f"{verb} {moved} file(s), skipped {skipped}, failed {failed}")
+    if failed:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/app/settings.py
+++ b/app/settings.py
@@ -24,6 +24,12 @@ REQUIRE_API_KEY_FOR_DELETE: bool = True
 MAX_API_KEY_ATTEMPTS_PER_MINUTE: int = 5
 ALLOW_REMOVE_BG: bool = False
 
+# When True, files are stored under 2-level 2-char subdirectories derived
+# from the filename prefix (e.g. /images/ab/cd/abcd...jpg) to keep each
+# directory small at TB scale. Best with NAME_STRATEGY=uuidv4; with
+# randomstr the 5-char namespace is small, so bucket density will be low.
+SHARD_STORAGE: bool = False
+
 VALID_SIZES: list[int] = []
 
 MAX_SIZE_MB: int = 16


### PR DESCRIPTION
## Summary
- New `SHARD_STORAGE` setting (default off). When enabled, files live under 2-level × 2-char subdirectories derived from the filename prefix, e.g. `/images/ab/cd/abcd1234.jpg`.
- Keeps each directory small at TB scale — \`readdir\`, backups, admin list, cache eviction all stay fast.
- **URLs unchanged.** Sharding is purely an internal layout detail; \`X-Sendfile\`/nginx need no config changes.
- New helper \`resolve_existing_path\` falls back to the flat location, so mixed-era installs keep working while you migrate.
- New \`app/migrate_shard.py\` script (idempotent, dry-run supported) relocates existing flat files into their shard paths.

## Tradeoffs / caveats
- Segment length (2) and depth (2) are constants, not configurable — chosen to match git/S3 conventions.
- Works best with \`NAME_STRATEGY=uuidv4\`. For \`randomstr\` (5-char names), sharding technically works but bucket density is low; noted in the setting's comment.
- Run the migration script with the app stopped (or uploads paused) on both \`IMAGES_DIR\` and \`CACHE_DIR\` before flipping the setting.

## Test plan
- [ ] With \`SHARD_STORAGE=False\`, uploads/GET/DELETE behave exactly as today (flat layout)
- [ ] With \`SHARD_STORAGE=True\`, a new upload lands at \`/images/ab/cd/abcd...ext\` and is readable via the same URL
- [ ] Resize variants land in the same shard path under \`/cache/\`
- [ ] DELETE removes both the image and its cached resized versions
- [ ] After toggling \`SHARD_STORAGE=True\` without migrating, legacy flat files are still served (mixed mode)
- [ ] \`python app/migrate_shard.py /images --dry-run\` shows planned moves; without \`--dry-run\` it actually relocates them; re-running is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)