### PR TITLE
Add S3-compatible storage backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Build stage
 FROM ubuntu:24.04 AS builder
 
-RUN apt-get update && \
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.kernel.org|g' /etc/apt/sources.list.d/ubuntu.sources && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
     python3-venv \
@@ -20,7 +21,8 @@ RUN uv sync --frozen --no-cache --no-dev --extra rembg
 # Runtime stage
 FROM ubuntu:24.04
 
-RUN apt-get update && \
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.kernel.org|g' /etc/apt/sources.list.d/ubuntu.sources && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     libmagickwand-dev \
     nginx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN /.venv/bin/python -c "from rembg import new_session; new_session('u2net')"
 
 RUN mkdir /images
 RUN mkdir /cache
+RUN mkdir /local_cache
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Build stage
 FROM ubuntu:24.04 AS builder
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.kernel.org|g' /etc/apt/sources.list.d/ubuntu.sources && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     python3 \
     python3-venv \
@@ -21,8 +20,7 @@ RUN uv sync --frozen --no-cache --no-dev --extra rembg
 # Runtime stage
 FROM ubuntu:24.04
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.kernel.org|g' /etc/apt/sources.list.d/ubuntu.sources && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libmagickwand-dev \
     nginx \

--- a/app/app.py
+++ b/app/app.py
@@ -18,6 +18,7 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware
+from storage import get_cache_storage, get_image_storage
 
 app = FastAPI(openapi_url=None)
 
@@ -180,9 +181,8 @@ async def upload_image(
         output_type = "svg"
 
     output_filename = os.path.basename(tmp_filepath) + f".{output_type}"
-    output_path = os.path.join(settings.IMAGES_DIR, output_filename)
 
-    error = imgpush.process_image(tmp_filepath, output_path, output_type, is_svg)
+    error = imgpush.process_image(tmp_filepath, output_filename, output_type, is_svg)
 
     if error:
         raise HTTPException(status_code=400, detail=error)
@@ -217,14 +217,15 @@ def get_image(
     w: str = Query(default=""),
     h: str = Query(default=""),
 ) -> FileResponse:
-    path = os.path.join(settings.IMAGES_DIR, filename)
+    image_storage = get_image_storage()
+    cache_storage = get_cache_storage()
 
-    if not os.path.isfile(path):
+    if not image_storage.file_exists(filename):
         raise HTTPException(status_code=404, detail="File not found")
 
     filename_without_extension, extension = os.path.splitext(filename)
 
-    if (w or h) and os.path.isfile(path) and extension not in (".mp4", ".svg"):
+    if (w or h) and extension not in (".mp4", ".svg"):
         try:
             width = imgpush.get_size_from_string(w)
             height = imgpush.get_size_from_string(h)
@@ -237,11 +238,16 @@ def get_image(
         dimensions = f"{width}x{height}"
         resized_filename = filename_without_extension + f"_{dimensions}{extension}"
 
-        resized_path = os.path.join(settings.CACHE_DIR, resized_filename)
-
-        if not os.path.isfile(resized_path) and (width or height):
+        if not cache_storage.file_exists(resized_filename) and (width or height):
             imgpush.clear_imagemagick_temp_files()
-            imgpush.resize_image(path, width, height, resized_path)
+            source_path = image_storage.get_local_path(filename)
+            # Resize to a temp file, then upload to cache storage
+            tmp_resized = f"/tmp/{resized_filename}"
+            imgpush.resize_image(source_path, width, height, tmp_resized)
+            cache_storage.upload_from_path(tmp_resized, resized_filename)
+
+        resized_path = cache_storage.get_local_path(resized_filename)
         return FileResponse(resized_path, headers={"X-Sendfile": resized_path})
 
-    return FileResponse(path, headers={"X-Sendfile": path})
+    local_path = image_storage.get_local_path(filename)
+    return FileResponse(local_path, headers={"X-Sendfile": local_path})

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import tempfile
 import urllib.request
 from typing import Any, Optional
 
@@ -217,6 +218,9 @@ def get_image(
     w: str = Query(default=""),
     h: str = Query(default=""),
 ) -> FileResponse:
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
     image_storage = get_image_storage()
     cache_storage = get_cache_storage()
 
@@ -241,10 +245,14 @@ def get_image(
         if not cache_storage.file_exists(resized_filename) and (width or height):
             imgpush.clear_imagemagick_temp_files()
             source_path = image_storage.get_local_path(filename)
-            # Resize to a temp file, then upload to cache storage
-            tmp_resized = f"/tmp/{resized_filename}"
-            imgpush.resize_image(source_path, width, height, tmp_resized)
-            cache_storage.upload_from_path(tmp_resized, resized_filename)
+            fd, tmp_resized = tempfile.mkstemp(suffix=extension, dir="/tmp")
+            os.close(fd)
+            try:
+                imgpush.resize_image(source_path, width, height, tmp_resized)
+                cache_storage.upload_from_path(tmp_resized, resized_filename)
+            finally:
+                if os.path.exists(tmp_resized):
+                    os.remove(tmp_resized)
 
         resized_path = cache_storage.get_local_path(resized_filename)
         return FileResponse(resized_path, headers={"X-Sendfile": resized_path})

--- a/app/imgpush.py
+++ b/app/imgpush.py
@@ -3,7 +3,6 @@ import gc
 import glob
 import os
 import random
-import shutil
 import string
 import time
 import uuid
@@ -11,6 +10,7 @@ from typing import Optional, Union
 
 import settings
 from PIL import Image as PILImage
+from storage import get_cache_storage, get_image_storage
 from wand.exceptions import MissingDelegateError
 from wand.image import Image
 
@@ -76,7 +76,8 @@ def clear_imagemagick_temp_files() -> None:
 def get_random_filename() -> str:
     random_string = generate_random_filename()
     if settings.NAME_STRATEGY == "randomstr":
-        file_exists = len(glob.glob(f"{settings.IMAGES_DIR}/{random_string}.*")) > 0
+        storage = get_image_storage()
+        file_exists = len(storage.list_files(f"{random_string}.")) > 0
         if file_exists:
             return get_random_filename()
     return random_string
@@ -165,25 +166,27 @@ def delete_image(filename: str) -> int:
     Raises PathTraversalError if filename attempts directory traversal.
     """
     # Sanitize filename to prevent path traversal
-    image_path = os.path.realpath(os.path.join(settings.IMAGES_DIR, filename))
-    images_dir = os.path.realpath(settings.IMAGES_DIR)
-
-    if not image_path.startswith(images_dir + os.sep):
+    if "/" in filename or "\\" in filename or ".." in filename:
         raise PathTraversalError("Invalid filename")
 
-    if not os.path.isfile(image_path):
+    image_storage = get_image_storage()
+    cache_storage = get_cache_storage()
+
+    if not image_storage.file_exists(filename):
         raise FileNotFoundError(f"Image {filename} not found")
 
-    os.remove(image_path)
+    image_storage.delete_file(filename)
 
-    # Also sanitize cache path - escape glob special chars in filename
-    safe_filename = os.path.basename(image_path)
-    filename_without_ext, extension = os.path.splitext(safe_filename)
-    cache_pattern = os.path.join(settings.CACHE_DIR, f"{glob.escape(filename_without_ext)}_*x*{glob.escape(extension)}")
-    cached_files = glob.glob(cache_pattern)
+    # Find and delete cached resized versions
+    filename_without_ext, extension = os.path.splitext(filename)
+    cached_files = [
+        f
+        for f in cache_storage.list_files(f"{filename_without_ext}_")
+        if f.endswith(extension)
+    ]
 
     for cached_file in cached_files:
-        os.remove(cached_file)
+        cache_storage.delete_file(cached_file)
 
     return len(cached_files)
 
@@ -209,34 +212,42 @@ def remove_background(filepath: str, autocrop: bool = False) -> None:
         result.close()
 
 
-def process_image(tmp_filepath: str, output_path: str, output_type: str, is_svg: bool = False) -> Optional[str]:
+def process_image(tmp_filepath: str, output_filename: str, output_type: str, is_svg: bool = False) -> Optional[str]:
     """Process and save image with appropriate format conversion"""
     error = None
+    storage = get_image_storage()
 
     try:
-        if os.path.exists(output_path):
+        if storage.file_exists(output_filename):
             raise CollisionError
         if output_type == "mp4":
             if settings.ALLOW_VIDEO:
-                shutil.move(tmp_filepath, output_path)
+                storage.upload_from_path(tmp_filepath, output_filename)
             else:
                 error = "Invalid Filetype"
         elif output_type == "svg":
-            shutil.move(tmp_filepath, output_path)
+            storage.upload_from_path(tmp_filepath, output_filename)
         else:
-            with Image(filename=tmp_filepath) as img:
-                img.strip()
-                if output_type not in ["gif", "webp"]:
-                    # Extract first frame for non-animated formats
-                    first_frame = img.sequence[0]  # type: ignore
-                    with Image(image=first_frame) as first_frame_img, first_frame_img.convert(output_type) as converted:
-                        converted.save(filename=output_path)
-                else:
-                    # Coalesce frames to ensure consistent dimensions for animated images
-                    # Required for WebP which doesn't support variable frame sizes
-                    img.coalesce()
-                    with img.convert(output_type) as converted:
-                        converted.save(filename=output_path)
+            # Process to a temp file, then upload
+            tmp_output = tmp_filepath + f".out.{output_type}"
+            try:
+                with Image(filename=tmp_filepath) as img:
+                    img.strip()
+                    if output_type not in ["gif", "webp"]:
+                        # Extract first frame for non-animated formats
+                        first_frame = img.sequence[0]  # type: ignore
+                        with Image(image=first_frame) as first_frame_img, first_frame_img.convert(output_type) as converted:
+                            converted.save(filename=tmp_output)
+                    else:
+                        # Coalesce frames to ensure consistent dimensions for animated images
+                        # Required for WebP which doesn't support variable frame sizes
+                        img.coalesce()
+                        with img.convert(output_type) as converted:
+                            converted.save(filename=tmp_output)
+                storage.upload_from_path(tmp_output, output_filename)
+            finally:
+                if os.path.exists(tmp_output):
+                    os.remove(tmp_output)
     except MissingDelegateError:
         error = "Invalid Filetype"
     finally:

--- a/app/settings.py
+++ b/app/settings.py
@@ -24,6 +24,17 @@ REQUIRE_API_KEY_FOR_DELETE: bool = True
 MAX_API_KEY_ATTEMPTS_PER_MINUTE: int = 5
 ALLOW_REMOVE_BG: bool = False
 
+STORAGE_BACKEND: str = "local"
+S3_ENDPOINT_URL: str = ""
+S3_ACCESS_KEY_ID: str = ""
+S3_SECRET_ACCESS_KEY: str = ""
+S3_BUCKET_NAME: str = ""
+S3_REGION: str = ""
+S3_IMAGES_PREFIX: str = "images/"
+S3_CACHE_PREFIX: str = "cache/"
+LOCAL_CACHE_DIR: str = "/local_cache/"
+LOCAL_CACHE_MAX_SIZE_MB: int = 2048
+
 VALID_SIZES: list[int] = []
 
 MAX_SIZE_MB: int = 16

--- a/app/storage.py
+++ b/app/storage.py
@@ -98,8 +98,11 @@ class S3StorageBackend(StorageBackend):
         try:
             self._client.head_object(Bucket=self._bucket, Key=self._s3_key(key))
             return True
-        except self._client.exceptions.ClientError:
-            return False
+        except self._client.exceptions.ClientError as e:
+            error_code: str = e.response["Error"]["Code"]
+            if error_code == "404" or error_code == "NoSuchKey":
+                return False
+            raise
 
     def read_file(self, key: str) -> bytes:
         response = self._client.get_object(Bucket=self._bucket, Key=self._s3_key(key))

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,186 @@
+import glob
+import os
+import shutil
+from abc import ABC, abstractmethod
+
+import settings
+
+
+class StorageBackend(ABC):
+    @abstractmethod
+    def file_exists(self, key: str) -> bool: ...
+
+    @abstractmethod
+    def read_file(self, key: str) -> bytes: ...
+
+    @abstractmethod
+    def write_file(self, key: str, data: bytes) -> None: ...
+
+    @abstractmethod
+    def upload_from_path(self, local_path: str, key: str) -> None: ...
+
+    @abstractmethod
+    def delete_file(self, key: str) -> None: ...
+
+    @abstractmethod
+    def list_files(self, prefix: str) -> list[str]: ...
+
+    @abstractmethod
+    def get_local_path(self, key: str) -> str: ...
+
+
+class LocalStorageBackend(StorageBackend):
+    def __init__(self, base_dir: str) -> None:
+        self._base_dir = base_dir
+
+    def _full_path(self, key: str) -> str:
+        return os.path.join(self._base_dir, key)
+
+    def file_exists(self, key: str) -> bool:
+        return os.path.isfile(self._full_path(key))
+
+    def read_file(self, key: str) -> bytes:
+        with open(self._full_path(key), "rb") as f:
+            return f.read()
+
+    def write_file(self, key: str, data: bytes) -> None:
+        with open(self._full_path(key), "wb") as f:
+            f.write(data)
+
+    def upload_from_path(self, local_path: str, key: str) -> None:
+        dest = self._full_path(key)
+        if local_path != dest:
+            shutil.move(local_path, dest)
+
+    def delete_file(self, key: str) -> None:
+        os.remove(self._full_path(key))
+
+    def list_files(self, prefix: str) -> list[str]:
+        pattern = os.path.join(self._base_dir, f"{glob.escape(prefix)}*")
+        return [os.path.basename(p) for p in glob.glob(pattern)]
+
+    def get_local_path(self, key: str) -> str:
+        return self._full_path(key)
+
+
+class S3StorageBackend(StorageBackend):
+    def __init__(self, prefix: str) -> None:
+        import boto3
+
+        self._prefix = prefix
+        self._bucket = settings.S3_BUCKET_NAME
+
+        kwargs: dict[str, str] = {}
+        if settings.S3_ENDPOINT_URL:
+            kwargs["endpoint_url"] = settings.S3_ENDPOINT_URL
+        if settings.S3_REGION:
+            kwargs["region_name"] = settings.S3_REGION
+
+        self._client = boto3.client(
+            "s3",
+            aws_access_key_id=settings.S3_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY,
+            **kwargs,
+        )
+
+        os.makedirs(settings.LOCAL_CACHE_DIR, exist_ok=True)
+
+    def _s3_key(self, key: str) -> str:
+        return self._prefix + key
+
+    def _cache_path(self, key: str) -> str:
+        return os.path.join(settings.LOCAL_CACHE_DIR, self._prefix.replace("/", "_") + key)
+
+    def file_exists(self, key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=self._s3_key(key))
+            return True
+        except self._client.exceptions.ClientError:
+            return False
+
+    def read_file(self, key: str) -> bytes:
+        response = self._client.get_object(Bucket=self._bucket, Key=self._s3_key(key))
+        return response["Body"].read()
+
+    def write_file(self, key: str, data: bytes) -> None:
+        self._client.put_object(Bucket=self._bucket, Key=self._s3_key(key), Body=data)
+
+    def upload_from_path(self, local_path: str, key: str) -> None:
+        self._client.upload_file(local_path, self._bucket, self._s3_key(key))
+
+    def delete_file(self, key: str) -> None:
+        self._client.delete_object(Bucket=self._bucket, Key=self._s3_key(key))
+        # Also remove from local cache if present
+        cache_path = self._cache_path(key)
+        if os.path.isfile(cache_path):
+            os.remove(cache_path)
+
+    def list_files(self, prefix: str) -> list[str]:
+        s3_prefix = self._s3_key(prefix)
+        result: list[str] = []
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=s3_prefix):
+            for obj in page.get("Contents", []):
+                key: str = obj["Key"]
+                result.append(key[len(self._prefix) :])
+        return result
+
+    def get_local_path(self, key: str) -> str:
+        cache_path = self._cache_path(key)
+        if os.path.isfile(cache_path):
+            return cache_path
+
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        self._client.download_file(self._bucket, self._s3_key(key), cache_path)
+        self._evict_local_cache()
+        return cache_path
+
+    def _evict_local_cache(self) -> None:
+        max_bytes = settings.LOCAL_CACHE_MAX_SIZE_MB * 1024 * 1024
+        cache_dir = settings.LOCAL_CACHE_DIR
+
+        files: list[tuple[str, float, int]] = []
+        total_size = 0
+        for entry in os.scandir(cache_dir):
+            if entry.is_file():
+                stat = entry.stat()
+                files.append((entry.path, stat.st_atime, stat.st_size))
+                total_size += stat.st_size
+
+        if total_size <= max_bytes:
+            return
+
+        # Sort by access time ascending (oldest first)
+        files.sort(key=lambda x: x[1])
+        for path, _, size in files:
+            if total_size <= max_bytes:
+                break
+            try:
+                os.remove(path)
+                total_size -= size
+            except OSError:
+                pass
+
+
+_image_storage: StorageBackend | None = None
+_cache_storage: StorageBackend | None = None
+
+
+def get_image_storage() -> StorageBackend:
+    global _image_storage
+    if _image_storage is None:
+        if settings.STORAGE_BACKEND == "s3":
+            _image_storage = S3StorageBackend(prefix=settings.S3_IMAGES_PREFIX)
+        else:
+            _image_storage = LocalStorageBackend(settings.IMAGES_DIR)
+    return _image_storage
+
+
+def get_cache_storage() -> StorageBackend:
+    global _cache_storage
+    if _cache_storage is None:
+        if settings.STORAGE_BACKEND == "s3":
+            _cache_storage = S3StorageBackend(prefix=settings.S3_CACHE_PREFIX)
+        else:
+            _cache_storage = LocalStorageBackend(settings.CACHE_DIR)
+    return _cache_storage

--- a/app/storage.py
+++ b/app/storage.py
@@ -31,10 +31,13 @@ class StorageBackend(ABC):
 
 class LocalStorageBackend(StorageBackend):
     def __init__(self, base_dir: str) -> None:
-        self._base_dir = base_dir
+        self._base_dir = os.path.realpath(base_dir)
 
     def _full_path(self, key: str) -> str:
-        return os.path.join(self._base_dir, key)
+        path = os.path.realpath(os.path.join(self._base_dir, key))
+        if not path.startswith(self._base_dir + os.sep) and path != self._base_dir:
+            raise ValueError(f"Path traversal detected: {key}")
+        return path
 
     def file_exists(self, key: str) -> bool:
         return os.path.isfile(self._full_path(key))

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -27,9 +27,15 @@ def client():
 @pytest.fixture
 def temp_dirs(monkeypatch):
     """Create temporary directories for images and cache."""
+    import storage
+
     with tempfile.TemporaryDirectory() as images_dir, tempfile.TemporaryDirectory() as cache_dir:
         monkeypatch.setattr("settings.IMAGES_DIR", images_dir)
         monkeypatch.setattr("settings.CACHE_DIR", cache_dir)
+        monkeypatch.setattr("settings.STORAGE_BACKEND", "local")
+        # Reset storage singletons so they pick up patched settings
+        monkeypatch.setattr(storage, "_image_storage", None)
+        monkeypatch.setattr(storage, "_cache_storage", None)
         yield {"images": images_dir, "cache": cache_dir}
 
 

--- a/app/tests/test_storage.py
+++ b/app/tests/test_storage.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+
+import pytest
+
+
+class TestLocalStorageBackend:
+    @pytest.fixture
+    def storage(self):
+        from storage import LocalStorageBackend
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield LocalStorageBackend(tmp_dir), tmp_dir
+
+    def test_write_and_read_file(self, storage):
+        backend, _ = storage
+        backend.write_file("test.txt", b"hello world")
+        assert backend.read_file("test.txt") == b"hello world"
+
+    def test_file_exists(self, storage):
+        backend, _ = storage
+        assert not backend.file_exists("missing.txt")
+        backend.write_file("exists.txt", b"data")
+        assert backend.file_exists("exists.txt")
+
+    def test_delete_file(self, storage):
+        backend, _ = storage
+        backend.write_file("to_delete.txt", b"data")
+        assert backend.file_exists("to_delete.txt")
+        backend.delete_file("to_delete.txt")
+        assert not backend.file_exists("to_delete.txt")
+
+    def test_upload_from_path(self, storage):
+        backend, base_dir = storage
+        # Create a temp file to upload
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"uploaded content")
+            src_path = f.name
+
+        try:
+            backend.upload_from_path(src_path, "uploaded.txt")
+            assert backend.read_file("uploaded.txt") == b"uploaded content"
+        finally:
+            if os.path.exists(src_path):
+                os.remove(src_path)
+
+    def test_list_files(self, storage):
+        backend, _ = storage
+        backend.write_file("abc.png", b"1")
+        backend.write_file("abc_100x100.png", b"2")
+        backend.write_file("abc_200x200.png", b"3")
+        backend.write_file("xyz.png", b"4")
+
+        result = backend.list_files("abc")
+        assert sorted(result) == ["abc.png", "abc_100x100.png", "abc_200x200.png"]
+
+    def test_get_local_path(self, storage):
+        backend, base_dir = storage
+        backend.write_file("test.png", b"data")
+        path = backend.get_local_path("test.png")
+        assert path == os.path.join(base_dir, "test.png")
+        assert os.path.isfile(path)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,18 @@ services:
       - ./app:/app
       - ./images:/images
       - ./cache:/cache
+      - ./local_cache:/local_cache
+    environment:
+      # STORAGE_BACKEND: "s3"  # "local" (default) or "s3"
+      # S3_ENDPOINT_URL: "https://<account-id>.r2.cloudflarestorage.com"
+      # S3_ACCESS_KEY_ID: ""
+      # S3_SECRET_ACCESS_KEY: ""
+      # S3_BUCKET_NAME: ""
+      # S3_REGION: ""
+      # S3_IMAGES_PREFIX: "images/"
+      # S3_CACHE_PREFIX: "cache/"
+      # LOCAL_CACHE_DIR: "/local_cache/"
+      # LOCAL_CACHE_MAX_SIZE_MB: "2048"
     healthcheck:
       start_period: 0s
       test: ['CMD-SHELL', 'curl localhost:5000/liveness -s -f -o /dev/null || exit 1']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "timeout-decorator==0.5.0",
     "nudenet==2.0.9",
     "opencv-python-headless==4.10.0.84",
+    "boto3>=1.35.0",
 ]
 
 [project.optional-dependencies]
@@ -34,6 +35,7 @@ dev = [
     "pytest==8.3.4",
     "httpx==0.28.1",
     "types-pillow==10.2.0.20240822",
+    "boto3-stubs[s3]>=1.35.0",
 ]
 
 [tool.basedpyright]

--- a/scripts/migrate_to_s3.py
+++ b/scripts/migrate_to_s3.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Migrate local imgpush images to an S3-compatible storage backend.
+
+Reads S3 configuration from environment variables (same as the app):
+  S3_ENDPOINT_URL, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY,
+  S3_BUCKET_NAME, S3_REGION, S3_IMAGES_PREFIX
+
+Usage:
+  python scripts/migrate_to_s3.py --images-dir /images
+  python scripts/migrate_to_s3.py --images-dir /images --dry-run
+  python scripts/migrate_to_s3.py --images-dir /images --verify
+"""
+
+import argparse
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import boto3
+
+
+def create_client(args: argparse.Namespace) -> boto3.client:
+    kwargs = {}
+    endpoint = os.environ.get("S3_ENDPOINT_URL", "")
+    region = os.environ.get("S3_REGION", "")
+    if endpoint:
+        kwargs["endpoint_url"] = endpoint
+    if region:
+        kwargs["region_name"] = region
+
+    return boto3.client(
+        "s3",
+        aws_access_key_id=os.environ["S3_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["S3_SECRET_ACCESS_KEY"],
+        **kwargs,
+    )
+
+
+def get_files(images_dir: str) -> list[str]:
+    files = []
+    for entry in os.scandir(images_dir):
+        if entry.is_file():
+            files.append(entry.name)
+    return sorted(files)
+
+
+def upload_file(client, bucket: str, prefix: str, images_dir: str, filename: str) -> tuple[str, int]:
+    local_path = os.path.join(images_dir, filename)
+    s3_key = prefix + filename
+    size = os.path.getsize(local_path)
+    client.upload_file(local_path, bucket, s3_key)
+    return filename, size
+
+
+def verify_file(client, bucket: str, prefix: str, images_dir: str, filename: str) -> tuple[str, bool]:
+    local_path = os.path.join(images_dir, filename)
+    s3_key = prefix + filename
+    local_size = os.path.getsize(local_path)
+
+    try:
+        response = client.head_object(Bucket=bucket, Key=s3_key)
+        remote_size = response["ContentLength"]
+        return filename, local_size == remote_size
+    except Exception:
+        return filename, False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate local images to S3-compatible storage")
+    parser.add_argument("--images-dir", required=True, help="Path to local images directory")
+    parser.add_argument("--dry-run", action="store_true", help="List files without uploading")
+    parser.add_argument("--verify", action="store_true", help="Verify uploaded files match local sizes")
+    parser.add_argument("--workers", type=int, default=8, help="Number of parallel upload workers (default: 8)")
+    args = parser.parse_args()
+
+    bucket = os.environ.get("S3_BUCKET_NAME", "")
+    prefix = os.environ.get("S3_IMAGES_PREFIX", "images/")
+
+    if not bucket:
+        print("Error: S3_BUCKET_NAME environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    files = get_files(args.images_dir)
+    total_files = len(files)
+
+    if total_files == 0:
+        print("No files found to migrate.")
+        return
+
+    print(f"Found {total_files} files in {args.images_dir}")
+
+    if args.dry_run:
+        total_size = 0
+        for filename in files:
+            size = os.path.getsize(os.path.join(args.images_dir, filename))
+            total_size += size
+            print(f"  {filename} ({size:,} bytes)")
+        print(f"\nTotal: {total_files} files, {total_size:,} bytes ({total_size / 1024 / 1024:.1f} MB)")
+        print("(dry run — no files uploaded)")
+        return
+
+    client = create_client(args)
+
+    if args.verify:
+        print("Verifying uploaded files...")
+        ok = 0
+        failed = []
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = {
+                executor.submit(verify_file, client, bucket, prefix, args.images_dir, f): f for f in files
+            }
+            for future in as_completed(futures):
+                filename, match = future.result()
+                if match:
+                    ok += 1
+                else:
+                    failed.append(filename)
+                print(f"\r  Verified {ok + len(failed)}/{total_files}", end="", flush=True)
+
+        print()
+        if failed:
+            print(f"\n{len(failed)} files FAILED verification:")
+            for f in failed:
+                print(f"  {f}")
+            sys.exit(1)
+        else:
+            print(f"All {ok} files verified successfully.")
+        return
+
+    # Upload
+    print(f"Uploading to s3://{bucket}/{prefix} with {args.workers} workers...")
+    uploaded = 0
+    total_bytes = 0
+    errors = []
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(upload_file, client, bucket, prefix, args.images_dir, f): f for f in files
+        }
+        for future in as_completed(futures):
+            try:
+                filename, size = future.result()
+                uploaded += 1
+                total_bytes += size
+                print(f"\r  Uploaded {uploaded}/{total_files} ({total_bytes / 1024 / 1024:.1f} MB)", end="", flush=True)
+            except Exception as e:
+                fname = futures[future]
+                errors.append((fname, str(e)))
+                print(f"\n  Error uploading {fname}: {e}")
+
+    print()
+    print(f"\nDone: {uploaded}/{total_files} files uploaded ({total_bytes / 1024 / 1024:.1f} MB)")
+    if errors:
+        print(f"{len(errors)} errors occurred:")
+        for fname, err in errors:
+            print(f"  {fname}: {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/stubs/boto3.pyi
+++ b/stubs/boto3.pyi
@@ -1,0 +1,6 @@
+"""Type stubs for boto3."""
+
+from typing import Any
+
+def client(service_name: str, **kwargs: Any) -> Any: ...
+def resource(service_name: str, **kwargs: Any) -> Any: ...

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,64 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.89"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/0c/f7bccb22b245cabf392816baba20f9e95f78ace7dbc580fd40136e80e732/boto3-1.42.89.tar.gz", hash = "sha256:3e43aacc0801bba9bcd23a8c271c089af297a69565f783fcdd357ae0e330bf1e", size = 113165, upload-time = "2026-04-13T19:36:17.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/33/55103ba5ef9975ea54b8d39e69b76eb6e9fded3beae5f01065e26951a3a1/boto3-1.42.89-py3-none-any.whl", hash = "sha256:6204b189f4d0c655535f43d7eaa57ff4e8d965b8463c97e45952291211162932", size = 140556, upload-time = "2026-04-13T19:36:13.894Z" },
+]
+
+[[package]]
+name = "boto3-stubs"
+version = "1.42.89"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/7d/2ea3bb15bba37e6d70f9297dccd1ce769b7b92f6179baa890293995f359b/boto3_stubs-1.42.89.tar.gz", hash = "sha256:dbbc4fd2678cfb21da9bab1b5e30ba951852322d055045ac12042ba34d04597a", size = 102703, upload-time = "2026-04-13T19:51:49.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/5d/397d2393cba13b6764da0da0aee5a16d05b304de081dfec1be69829ef0d4/boto3_stubs-1.42.89-py3-none-any.whl", hash = "sha256:699e510078a057766e2de1d2d91d99dac2ce3ca2d4e6adf8df27b305d04b91d2", size = 70667, upload-time = "2026-04-13T19:51:43.131Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "mypy-boto3-s3" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.89"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/cc/e6be943efa9051bd15c2ee14077c2b10d6e27c9e9385fc43a03a5c4ed8b5/botocore-1.42.89.tar.gz", hash = "sha256:95ac52f472dad29942f3088b278ab493044516c16dbf9133c975af16527baa99", size = 15206290, upload-time = "2026-04-13T19:36:02.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f1/90a7b8eda38b7c3a65ca7ee0075bdf310b6b471cb1b95fab6e8994323a50/botocore-1.42.89-py3-none-any.whl", hash = "sha256:d9b786c8d9db6473063b4cc5be0ba7e6a381082307bd6afb69d4216f9fa95f35", size = 14887287, upload-time = "2026-04-13T19:35:56.677Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -278,6 +336,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "filetype" },
     { name = "nudenet" },
@@ -292,6 +351,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "boto3-stubs", extra = ["s3"] },
     { name = "httpx" },
     { name = "pytest" },
     { name = "ruff" },
@@ -305,6 +365,8 @@ rembg = [
 requires-dist = [
     { name = "aiofiles", specifier = "==24.1.0" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = "==1.31.3" },
+    { name = "boto3", specifier = ">=1.35.0" },
+    { name = "boto3-stubs", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=1.35.0" },
     { name = "fastapi", specifier = "==0.115.6" },
     { name = "filetype", specifier = "==1.2.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = "==0.28.1" },
@@ -329,6 +391,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -415,6 +486,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/5e/026461fef8e163ec261df1668ee88611124170bb4da3d1b144c970e7c9b4/mypy_boto3_s3-1.42.85.tar.gz", hash = "sha256:401e3a184ac0973bc08b556cc3b2655d8f2e56570b6ed87ce635210df4f666fb", size = 76543, upload-time = "2026-04-07T19:51:20.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/58/fb6373ca66898620ecb7b9ab92563f3f7277627994bc4ceba75c721de4a1/mypy_boto3_s3-1.42.85-py3-none-any.whl", hash = "sha256:b2cad995ea733b16ae3be5510fd6a0038aa44400c22d010d4def9286cf6eaf82", size = 83751, upload-time = "2026-04-07T19:51:17.727Z" },
 ]
 
 [[package]]
@@ -867,6 +947,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1048,6 +1140,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "scikit-image"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1167,6 +1271,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "slowapi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1233,12 +1346,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
 name = "types-pillow"
 version = "10.2.0.20240822"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/4a/4495264dddaa600d65d68bcedb64dcccf9d9da61adff51f7d2ffd8e4c9ce/types-Pillow-10.2.0.20240822.tar.gz", hash = "sha256:559fb52a2ef991c326e4a0d20accb3bb63a7ba8d40eb493e0ecb0310ba52f0d3", size = 35389, upload-time = "2024-08-22T02:32:48.15Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/23/e81a5354859831fcf54d488d33b80ba6133ea84f874a9c0ec40a4881e133/types_Pillow-10.2.0.20240822-py3-none-any.whl", hash = "sha256:d9dab025aba07aeb12fd50a6799d4eac52a9603488eca09d7662543983f16c5d", size = 54354, upload-time = "2024-08-22T02:32:46.664Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a `StorageBackend` abstraction (`app/storage.py`) with `LocalStorageBackend` and `S3StorageBackend` implementations, supporting any S3-compatible provider (Cloudflare R2, AWS S3, MinIO, etc.)
- Refactor `imgpush.py` and `app.py` to use the storage backend instead of direct filesystem operations — all image upload, serve, resize, and delete flows go through the abstraction
- When using S3, images are downloaded to a local disk cache on first access and served via nginx X-Accel-Redirect as before, with LRU eviction when cache exceeds `LOCAL_CACHE_MAX_SIZE_MB`
- Default `STORAGE_BACKEND=local` preserves existing behavior with zero functional change
- Includes a parallel migration script (`scripts/migrate_to_s3.py`) with `--dry-run` and `--verify` flags

## Configuration

Set these env vars to enable S3 storage:
```
STORAGE_BACKEND=s3
S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com  # or leave empty for AWS S3
S3_ACCESS_KEY_ID=...
S3_SECRET_ACCESS_KEY=...
S3_BUCKET_NAME=...
S3_REGION=...  # optional
```

## Test plan
- [x] All 23 existing tests pass with local backend (no regressions)
- [x] 6 new `LocalStorageBackend` unit tests pass
- [x] `ruff check` clean
- [x] `basedpyright` 0 errors
- [ ] Manual test with S3 credentials: upload, serve, resize, delete
- [ ] Run migration script against test bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)